### PR TITLE
Fix InterpolatorTest

### DIFF
--- a/jboss-seam/src/test/java/org/jboss/seam/test/unit/InterpolatorTest.java
+++ b/jboss-seam/src/test/java/org/jboss/seam/test/unit/InterpolatorTest.java
@@ -49,7 +49,7 @@ public class InterpolatorTest extends MockContainerTest
         
         Date date = new Date(0);
                 
-        Assert.assertEquals(interpolator.interpolate("{0,date,short}", date), DateFormat.getDateInstance(DateFormat.SHORT).format(date)); 
+        Assert.assertEquals(interpolator.interpolate("{0,date,short}", date), DateFormat.getDateInstance(DateFormat.SHORT, Locale.instance()).format(date));
         
         // test that a messageformat error doesn't blow up
         Assert.assertEquals(interpolator.interpolate("{nosuchmessage}"), "{nosuchmessage}");


### PR DESCRIPTION
The test made a straight forward comparison between the Interpolator and
DateFormat without taking into account that the former applies the
Locale.

Added Locale for the assert to pass.