### PR TITLE
Use version-richfaces-cdk references.

### DIFF
--- a/jboss-seam-ui/pom.xml
+++ b/jboss-seam-ui/pom.xml
@@ -15,7 +15,7 @@
             <plugin>
                 <groupId>org.richfaces.cdk</groupId>
                 <artifactId>richfaces-cdk-maven-plugin</artifactId>
-                <version>4.5.0.Final</version>
+                <version>${version.richfaces.cdk}</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>


### PR DESCRIPTION
The property was already available in the parent pom but the plugin did
not reference the variable.

Added the property reference to the plugin definition.

I needed to do new build of richfaces-cdk in order for the jboss-seam-ui to compile as the 4.5.0 maven plugin complained about library version mismatch and died. In order to simply update the property on the command line to change the version this reference needed to be set.