### PR TITLE
Clean jar-dependencies folder.

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -14,16 +14,6 @@
 
 	<build>
 		<plugins>
-         <!--          <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>../jar-dependencies</directory>
-                        </fileset>
-                    </filesets>
-                </configuration>
-             </plugin> -->
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>

--- a/jboss-seam-debug/pom.xml
+++ b/jboss-seam-debug/pom.xml
@@ -65,7 +65,6 @@
                                     <outputDirectory>../jar-dependencies</outputDirectory>       
                                     <stripVersion>true</stripVersion>                             
                                     <type>jar</type>
-                                    <transitive>true</transitive>
                                 </configuration>
                             </execution>
                      </executions>

--- a/jboss-seam-excel/pom.xml
+++ b/jboss-seam-excel/pom.xml
@@ -114,7 +114,6 @@
                                     <outputDirectory>../jar-dependencies</outputDirectory> 
                                     <stripVersion>true</stripVersion>                                   
                                     <type>jar</type>
-                                    <transitive>true</transitive>
                                 </configuration>
                             </execution>
                      </executions>

--- a/jboss-seam-flex/pom.xml
+++ b/jboss-seam-flex/pom.xml
@@ -84,7 +84,6 @@
                                     <outputDirectory>../jar-dependencies</outputDirectory>   
                                     <stripVersion>true</stripVersion>                                 
                                     <type>jar</type>
-                                    <transitive>true</transitive>
                                 </configuration>
                             </execution>
                      </executions>

--- a/jboss-seam-ioc/pom.xml
+++ b/jboss-seam-ioc/pom.xml
@@ -123,7 +123,6 @@
                                     <outputDirectory>../jar-dependencies</outputDirectory>
                                     <stripVersion>true</stripVersion>
                                     <type>jar</type>
-                                    <transitive>true</transitive>
                                 </configuration>
                             </execution>
                      </executions>

--- a/jboss-seam-mail/pom.xml
+++ b/jboss-seam-mail/pom.xml
@@ -87,7 +87,6 @@
                                     <outputDirectory>../jar-dependencies</outputDirectory>
                                     <stripVersion>true</stripVersion>
                                     <type>jar</type>
-                                    <transitive>true</transitive>
                                 </configuration>
                             </execution>
                      </executions>

--- a/jboss-seam-pdf/pom.xml
+++ b/jboss-seam-pdf/pom.xml
@@ -91,7 +91,6 @@
                                     <outputDirectory>../jar-dependencies</outputDirectory>
                                     <stripVersion>true</stripVersion>
                                     <type>jar</type>
-                                    <transitive>true</transitive>
                                 </configuration>
                             </execution>
                      </executions>

--- a/jboss-seam-remoting/pom.xml
+++ b/jboss-seam-remoting/pom.xml
@@ -125,7 +125,6 @@
                                     <outputDirectory>../jar-dependencies</outputDirectory>
                                     <stripVersion>true</stripVersion>
                                     <type>jar</type>
-                                    <transitive>true</transitive>
                                 </configuration>
                             </execution>
                      </executions>

--- a/jboss-seam-resteasy/pom.xml
+++ b/jboss-seam-resteasy/pom.xml
@@ -110,7 +110,6 @@
                                     <outputDirectory>../jar-dependencies</outputDirectory>
                                     <stripVersion>true</stripVersion>
                                     <type>jar</type>
-                                    <transitive>true</transitive>
                                 </configuration>
                             </execution>
                      </executions>

--- a/jboss-seam-rss/pom.xml
+++ b/jboss-seam-rss/pom.xml
@@ -78,7 +78,6 @@
                                     <outputDirectory>../jar-dependencies</outputDirectory>
                                     <stripVersion>true</stripVersion>
                                     <type>jar</type>
-                                    <transitive>true</transitive>
                                 </configuration>
                             </execution>
                      </executions>

--- a/jboss-seam-ui/pom.xml
+++ b/jboss-seam-ui/pom.xml
@@ -242,7 +242,6 @@
                                     <outputDirectory>../jar-dependencies</outputDirectory>
                                     <stripVersion>true</stripVersion>
                                     <type>jar</type>
-                                    <transitive>true</transitive>
                                 </configuration>
                             </execution>
                         </executions>

--- a/jboss-seam-wicket/pom.xml
+++ b/jboss-seam-wicket/pom.xml
@@ -119,7 +119,6 @@
                                     <outputDirectory>../jar-dependencies</outputDirectory>
                                     <stripVersion>true</stripVersion>
                                     <type>jar</type>
-                                    <transitive>true</transitive>
                                 </configuration>
                             </execution>
                      </executions>

--- a/jboss-seam/pom.xml
+++ b/jboss-seam/pom.xml
@@ -19,7 +19,20 @@
 	</properties>	
 
 	<build>
-		<plugins>
+        <plugins>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <configuration>
+                    <filesets>
+                        <fileset>
+                            <directory>../</directory>
+                            <includes>
+                                <include>jar-dependencies/*</include>
+                            </includes>
+                      </fileset>
+                    </filesets>
+                </configuration>
+            </plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>antlr-maven-plugin</artifactId>

--- a/jboss-seam/pom.xml
+++ b/jboss-seam/pom.xml
@@ -476,7 +476,6 @@
                                     <outputDirectory>../jar-dependencies</outputDirectory>
                                     <stripVersion>true</stripVersion>
                                     <type>jar</type>
-                                    <transitive>true</transitive>
                                 </configuration>
                             </execution>
                         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 	<url>http://seamframework.org/Seam2</url>
 
 	<properties>
-		<version.dependency.plugin>2.10</version.dependency.plugin>
+		<version.dependency.plugin>3.0.1</version.dependency.plugin>
 		<!-- General properties -->
         <project.short.version>2.3</project.short.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -374,7 +374,7 @@
 		</pluginManagement>
 
 		<plugins>
-			<plugin>
+            <plugin>
 				<artifactId>maven-source-plugin</artifactId>
 				<configuration>
 					<archive>


### PR DESCRIPTION
The build phase folder jar-dependencies, used to collect all module
dependencies for use in distribution, never gets cleaned.

At some point someone attempted this as part of the distribution module
but it gets a full lifecycle build in profile distribution and will
clean the folder before it has a chance to use it. The responsibility
then goes to the first module in the normal build process which
populates this folder.

The maven-dependency-plugin's copy-dependencies goal has no
transitive=true property. It does have an excludeTransitive
property, default = false. This can't be the intent or copy
would've been used instead of copy-dependencies.

Removed to avoid further confusion.

Upgrade maven-dependency-plugin to version 3.0.1.