### PR TITLE
Swap SeamApplication from using Application to use ApplicationWrapper indead

### DIFF
--- a/jboss-seam/src/main/java/org/jboss/seam/jsf/SeamApplication.java
+++ b/jboss-seam/src/main/java/org/jboss/seam/jsf/SeamApplication.java
@@ -1,31 +1,13 @@
 package org.jboss.seam.jsf;
 
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.Locale;
-import java.util.Map;
-import java.util.ResourceBundle;
 
-import javax.el.ELContextListener;
-import javax.el.ELException;
-import javax.el.ELResolver;
+import java.util.Map;
 import javax.el.ExpressionFactory;
-import javax.el.ValueExpression;
 import javax.faces.FacesException;
 import javax.faces.application.Application;
-import javax.faces.application.NavigationHandler;
-import javax.faces.application.ProjectStage;
-import javax.faces.application.Resource;
-import javax.faces.application.ResourceHandler;
-import javax.faces.application.StateManager;
-import javax.faces.application.ViewHandler;
-import javax.faces.component.UIComponent;
-import javax.faces.component.behavior.Behavior;
+import javax.faces.application.ApplicationWrapper;
 import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
-import javax.faces.event.ActionListener;
-import javax.faces.event.SystemEvent;
-import javax.faces.event.SystemEventListener;
 import javax.faces.validator.Validator;
 import javax.servlet.ServletContext;
 
@@ -38,11 +20,15 @@ import org.jboss.seam.el.SeamExpressionFactory;
 /**
  * Proxies the JSF Application object, and adds all kinds
  * of tasty extras.
- * 
+ *
+ * Extending javax.faces.application.ApplicationWrapper
+ * so all JSF 2.2+ functions is available without needing to change this class
+ *
  * @author Gavin King
+ * @author William Dutton
  *
  */
-public class SeamApplication extends Application {
+public class SeamApplication extends ApplicationWrapper {
 
 	protected Application application;
 
@@ -55,50 +41,22 @@ public class SeamApplication extends Application {
 	}
 
 	@Override
-	public ELResolver getELResolver() {
-		return application.getELResolver();
+	public Application getWrapped() {
+		return application;
 	}
 
-	@Override
-	public void addComponent(String componentType, String componentClass) {
-		application.addComponent(componentType, componentClass);
-	}
-
-	@Override
-	public void addConverter(String converterId, String converterClass) {
-		application.addConverter(converterId, converterClass);
-	}
-
-	@Override
-	public void addConverter(Class<?> targetClass, String converterClass) {
-		application.addConverter(targetClass, converterClass);
-	}
-
-	@Override
-	public void addValidator(String validatorId, String validatorClass) {
-		application.addValidator(validatorId, validatorClass);
-	}
-
-	@Override
-	public UIComponent createComponent(String componentType) throws FacesException {
-		return application.createComponent(componentType);
-	}
-
-	@Override
-	public UIComponent createComponent(FacesContext context, String componentType, String rendererType) {
-		return application.createComponent(context, componentType, rendererType);
-	}
-
-	@Override
-	public UIComponent createComponent(FacesContext context, Resource resource) {
-		return application.createComponent(context, resource);
-	}
-
+	/**
+	 * <p class="changed_added_2_0">The default behavior of this method
+	 * is to call {@link Application#createConverter(String)} on the
+	 * wrapped {@link Application} object.
+	 * IF ApplicationContext is NOT Active and converterId is NULL
+	 * else return Component.getInstance by id</p>
+	 */
 	@Override
 	public Converter createConverter(String converterId) {
-		if (Contexts.isApplicationContextActive()) {
+		if ( Contexts.isApplicationContextActive() ) {
 			String name = Init.instance().getConverters().get(converterId);
-			if (name != null) {
+			if (name!=null) {
 				return (Converter) Component.getInstance(name);
 			}
 		}
@@ -108,7 +66,7 @@ public class SeamApplication extends Application {
 	@Override
 	public Converter createConverter(Class<?> targetClass) {
 		Converter converter = null;
-		if (Contexts.isApplicationContextActive()) {
+		if ( Contexts.isApplicationContextActive() ) {
 			converter = new ConverterLocator(targetClass).getConverter();
 		}
 		if (converter == null) {
@@ -145,7 +103,7 @@ public class SeamApplication extends Application {
 				return;
 			}
 
-			for (Class<?> _interface : clazz.getInterfaces()) {
+			for (Class<?> _interface: clazz.getInterfaces()) {
 				if (converters.containsKey(_interface)) {
 					converter = createConverter(_interface);
 					return;
@@ -169,141 +127,19 @@ public class SeamApplication extends Application {
 
 	@Override
 	public Validator createValidator(String validatorId) throws FacesException {
-		if (Contexts.isApplicationContextActive()) {
+		if ( Contexts.isApplicationContextActive() ) {
 			String name = Init.instance().getValidators().get(validatorId);
-			if (name != null) {
+			if (name!=null) {
 				return (Validator) Component.getInstance(name);
 			}
 		}
 		return application.createValidator(validatorId);
 	}
 
-	@Override
-	public ActionListener getActionListener() {
-		return application.getActionListener();
-	}
-
-	@Override
-	public Iterator<String> getComponentTypes() {
-		return application.getComponentTypes();
-	}
-
-	@Override
-	public Iterator<String> getConverterIds() {
-		return application.getConverterIds();
-	}
-
-	@Override
-	public Iterator<Class<?>> getConverterTypes() {
-		return application.getConverterTypes();
-	}
-
-	@Override
-	public Locale getDefaultLocale() {
-		return application.getDefaultLocale();
-	}
-
-	@Override
-	public String getDefaultRenderKitId() {
-		return application.getDefaultRenderKitId();
-	}
-
-	@Override
-	public String getMessageBundle() {
-		return application.getMessageBundle();
-	}
-
-	@Override
-	public NavigationHandler getNavigationHandler() {
-		return application.getNavigationHandler();
-	}
-
-	@Override
-	public StateManager getStateManager() {
-		return application.getStateManager();
-	}
-
-	@Override
-	public Iterator<Locale> getSupportedLocales() {
-		return application.getSupportedLocales();
-	}
-
-	@Override
-	public Iterator<String> getValidatorIds() {
-		return application.getValidatorIds();
-	}
-
-	@Override
-	public ViewHandler getViewHandler() {
-		return application.getViewHandler();
-	}
-
-	@Override
-	public void setActionListener(ActionListener listener) {
-		application.setActionListener(listener);
-	}
-
-	@Override
-	public void setDefaultLocale(Locale locale) {
-		application.setDefaultLocale(locale);
-	}
-
-	@Override
-	public void setDefaultRenderKitId(String renderKitId) {
-		application.setDefaultRenderKitId(renderKitId);
-	}
-
-	@Override
-	public void setMessageBundle(String bundle) {
-		application.setMessageBundle(bundle);
-	}
-
-	@Override
-	public void setNavigationHandler(NavigationHandler handler) {
-		application.setNavigationHandler(handler);
-	}
-
-	@Override
-	public void setStateManager(StateManager manager) {
-		application.setStateManager(manager);
-	}
-
-	@Override
-	public void setSupportedLocales(Collection<Locale> locales) {
-		application.setSupportedLocales(locales);
-	}
-
-	@Override
-	public void setViewHandler(ViewHandler handler) {
-		application.setViewHandler(handler);
-	}
-
-	@Override
-	public void addELContextListener(ELContextListener elcl) {
-		application.addELContextListener(elcl);
-	}
-
-	@Override
-	public void addELResolver(ELResolver elr) {
-		application.addELResolver(elr);
-	}
-
-	@Override
-	public UIComponent createComponent(ValueExpression ve, FacesContext fc, String id) throws FacesException {
-		return application.createComponent(ve, fc, id);
-	}
-
-	@SuppressWarnings("unchecked")
-	@Override
-	public <T> T evaluateExpressionGet(FacesContext ctx, String expr, Class<? extends T> type) throws ELException {
-		return (T) getExpressionFactory().createValueExpression(ctx.getELContext(), expr, type).getValue(ctx.getELContext());
-	}
-
-	@Override
-	public ELContextListener[] getELContextListeners() {
-		return application.getELContextListeners();
-	}
-
+	/**
+	 * Overrides default behavior of jsf 2.2 api spec
+	 * by using SEAM version instead of JSF Application version.
+	 */
 	@Override
 	public ExpressionFactory getExpressionFactory() {
 		//JBoss EL
@@ -311,181 +147,11 @@ public class SeamApplication extends Application {
 	}
 
 	@Override
-	public ResourceBundle getResourceBundle(FacesContext fc, String name) {
-		return application.getResourceBundle(fc, name);
-	}
-
-	@Override
-	public void removeELContextListener(ELContextListener elcl) {
-		application.removeELContextListener(elcl);
-	}
-
-	@Override
 	public String toString() {
 		return application.toString();
 	}
 
-	@Override
-	public void publishEvent(FacesContext context, Class<? extends SystemEvent> systemEventClass, Object source) {
-		application.publishEvent(context, systemEventClass, source);
-	}
-
-	@Override
-	public void publishEvent(FacesContext context, Class<? extends SystemEvent> systemEventClass, Class<?> sourceBaseType, Object source) {
-		application.publishEvent(context, systemEventClass, sourceBaseType, source);
-	}
-
-	/* (non-Javadoc)
-	* @see javax.faces.application.Application#createBehavior(java.lang.String)
-	*/
-	@Override
-	public Behavior createBehavior(String behaviorId) throws FacesException {
-		return application.createBehavior(behaviorId);
-	}
-
-	/* (non-Javadoc)
-	* @see javax.faces.application.Application#getBehaviorIds()
-	*/
-	@Override
-	public Iterator<String> getBehaviorIds() {
-		return application.getBehaviorIds();
-	}
-
-	/* (non-Javadoc)
-	* @see javax.faces.application.Application#getResourceHandler()
-	*/
-	@Override
-	public ResourceHandler getResourceHandler() {
-		return application.getResourceHandler();
-	}
-
-	/* (non-Javadoc)
-	* @see javax.faces.application.Application#setResourceHandler(javax.faces.application.ResourceHandler)
-	*/
-	@Override
-	public void setResourceHandler(ResourceHandler resourceHandler) {
-		application.setResourceHandler(resourceHandler);
-	}
-
-	/* (non-Javadoc)
-	* @see javax.faces.application.Application#getProjectStage()
-	*/
-	@Override
-	public ProjectStage getProjectStage() {
-		return application.getProjectStage();
-	}
-
-	/* (non-Javadoc)
-	* @see javax.faces.application.Application#addBehavior(java.lang.String, java.lang.String)
-	*/
-	@Override
-	public void addBehavior(String behaviorId, String behaviorClass) {
-		application.addBehavior(behaviorId, behaviorClass);
-	}
-
-	/* (non-Javadoc)
-	* @see javax.faces.application.Application#createComponent(javax.el.ValueExpression, javax.faces.context.FacesContext, java.lang.String, java.lang.String)
-	*/
-	@Override
-	public UIComponent createComponent(ValueExpression componentExpression, FacesContext context, String componentType,
-			String rendererType) {
-		return application.createComponent(componentExpression, context, componentType, rendererType);
-	}
-
-	/* (non-Javadoc)
-	* @see javax.faces.application.Application#addDefaultValidatorId(java.lang.String)
-	*/
-	@Override
-	public void addDefaultValidatorId(String validatorId) {
-		application.addDefaultValidatorId(validatorId);
-	}
-
-	/* (non-Javadoc)
-	* @see javax.faces.application.Application#getDefaultValidatorInfo()
-	*/
-	@Override
-	public Map<String, String> getDefaultValidatorInfo() {
-		return application.getDefaultValidatorInfo();
-	}
-
-	/* (non-Javadoc)
-	* @see javax.faces.application.Application#subscribeToEvent(java.lang.Class, java.lang.Class, javax.faces.event.SystemEventListener)
-	*/
-	@Override
-	public void subscribeToEvent(Class<? extends SystemEvent> systemEventClass, Class<?> sourceClass, SystemEventListener listener) {
-		application.subscribeToEvent(systemEventClass, sourceClass, listener);
-	}
-
-	/* (non-Javadoc)
-	* @see javax.faces.application.Application#subscribeToEvent(java.lang.Class, javax.faces.event.SystemEventListener)
-	*/
-	@Override
-	public void subscribeToEvent(Class<? extends SystemEvent> systemEventClass, SystemEventListener listener) {
-		application.subscribeToEvent(systemEventClass, listener);
-	}
-
-	/* (non-Javadoc)
-	* @see javax.faces.application.Application#unsubscribeFromEvent(java.lang.Class, java.lang.Class, javax.faces.event.SystemEventListener)
-	*/
-	@Override
-	public void unsubscribeFromEvent(Class<? extends SystemEvent> systemEventClass, Class<?> sourceClass, SystemEventListener listener) {
-		application.unsubscribeFromEvent(systemEventClass, sourceClass, listener);
-	}
-
-	/* (non-Javadoc)
-	* @see javax.faces.application.Application#unsubscribeFromEvent(java.lang.Class, javax.faces.event.SystemEventListener)
-	*/
-	@Override
-	public void unsubscribeFromEvent(Class<? extends SystemEvent> systemEventClass, SystemEventListener listener) {
-		application.unsubscribeFromEvent(systemEventClass, listener);
-	}
-
-	@Override
-	@Deprecated
-	public javax.faces.el.MethodBinding createMethodBinding(String expression, Class<?>[] params)
-			throws javax.faces.el.ReferenceSyntaxException {
-		return new UnifiedELMethodBinding(expression, params);
-
-	}
-
-	@Override
-	@Deprecated
-	public javax.faces.el.ValueBinding createValueBinding(String expression) throws javax.faces.el.ReferenceSyntaxException {
-		return new UnifiedELValueBinding(expression);
-	}
-
-	@Override
-	@Deprecated
-	public javax.faces.el.PropertyResolver getPropertyResolver() {
-		return application.getPropertyResolver();
-	}
-
-	@Override
-	@Deprecated
-	public javax.faces.el.VariableResolver getVariableResolver() {
-		return application.getVariableResolver();
-	}
-
-	@Override
-	@Deprecated
-	public void setPropertyResolver(javax.faces.el.PropertyResolver resolver) {
-		application.setPropertyResolver(resolver);
-	}
-
-	@Override
-	@Deprecated
-	public void setVariableResolver(javax.faces.el.VariableResolver resolver) {
-		application.setVariableResolver(resolver);
-	}
-
-	@Override
-	@Deprecated
-	public UIComponent createComponent(javax.faces.el.ValueBinding componentBinding, FacesContext context, String componentType)
-			throws FacesException {
-		return application.createComponent(componentBinding, context, componentType);
-	}
-
-	public static boolean isSeamApplication(FacesContext facesContext) {
+	public static boolean isSeamApplication (FacesContext facesContext) {
 		ServletContext servletContext = (ServletContext) facesContext.getExternalContext().getContext();
 		Object attributeVersion = servletContext.getAttribute(Seam.VERSION);
 		return attributeVersion != null;


### PR DESCRIPTION
Patch for problem below:
Seam in JSF 2.2 causes java.lang.NullPointerException at
com.sun.faces.application.NavigationHandlerImpl.determineViewFromActionOutcome

This is caused by the combination Seam 2.3.x and JSF 2.2.

The technical problem is, Seam used an Application implementation which
didn't properly extend from javax.faces.application.ApplicationWrapper
and thus it had to manually implement/delegate all Application methods
to the wrapped application. In case of Seam 2.3.x, all those methods were
based on JSF 2.1.

In JSF 2.2, a new method getFlowHandler() was added to Application,
which wasn't properly delegated by Seam and thus returned null, causing
all the trouble further down in the chain relying on it not being null.
If Seam guys had properly extended from ApplicationWrapper instead of
hardcoding all delegate methods for a specific JSF version, then it would
flawlessly have worked across JSF versions.

See also:
Weld in JSF 2.2 causes java.lang.NullPointerException at
com.sun.faces.application.NavigationHandlerImpl.determineViewFromActionOutcome
(exactly same problem with older Weld versions)
SWF in JSF 2.2 causes java.lang.NullPointerException at
com.sun.faces.application.NavigationHandlerImpl.determineViewFromActionOutcome
(exactly same problem with older Spring WebFlow versions)

https://stackoverflow.com/questions/31427272/seam-in-jsf-2-2-causes-java-lang-nullpointerexception-at-com-sun-faces-applicati