### PR TITLE
Add docker-compose with wildfly10.1.0.Final with README text

### DIFF
--- a/examples/.docker/.gitignore
+++ b/examples/.docker/.gitignore
@@ -1,0 +1,4 @@
+deployments/*.ear
+deployments/*.deployed
+deployments/*.undeployed
+deployments/*.failed

--- a/examples/.docker/Dockerfile-wildfly10
+++ b/examples/.docker/Dockerfile-wildfly10
@@ -1,0 +1,10 @@
+FROM jboss/wildfly:10.1.0.Final
+
+RUN /opt/jboss/wildfly/bin/add-user.sh "admin" "Admin#70365" --silent
+
+RUN sed -i \
+        -e 's|\(<https-listener\)|<ajp-listener name="ajp" socket-binding="ajp" scheme="http" enabled="true"/>\1|' \
+        -e 's|^<subsystem xmlns="urn:jboss:domain:weld:3.0"/>|<subsystem xmlns="urn:jboss:domain:weld:3.0" require-bean-descriptor="true"/>|' \
+        /opt/jboss/wildfly/standalone/configuration/standalone.xml
+
+CMD ["/opt/jboss/wildfly/bin/standalone.sh", "-b", "0.0.0.0", "-bmanagement", "0.0.0.0"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -85,3 +85,48 @@ To run a functional test:
 To run all functional tests:
 
     mvn clean test -Dftest
+
+### How to Build and Deploy an Docker Wildfly
+
+1. Download and install Docker and docker-compose
+
+2. Build the example by running the following command from the Seam `examples/${example.name}` directory:
+   
+        mvn clean install
+
+   _NOTE: There is an option to create an "exploded" archive. For this purpose, use `-Pexploded` maven profile._
+
+3. Start Wildfly in new terminal
+
+        docker-compose up
+        
+4. Deploy the example by
+ 
+        copying the ear file to examples/.docker/deployments/ 
+         
+   To undeploy the example:
+
+        remove ear/war from examples/.docker/deployments/
+5. Watch logs on docker-compose terminal window or via admin console 
+
+        http://localhost:9990 
+ 
+    with username / password 
+
+         admin / Admin#70365
+
+6. Point your web browser to:
+
+        http://localhost:8080/seam-${example.name}
+
+   The context path is set to the final name of the EAR archive.
+
+   However, WAR deployments use a different naming convention for the context
+   path. If you deploy a WAR example, point your web browser to:
+
+        http://localhost:8080/${example.name}-web
+
+   The WAR examples are:
+   spring, jpa, hibernate, groovybooking.
+
+_NOTE: The examples use the H2 database embedded in JBoss AS_

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3'
+
+services:
+  wildfly:
+    #image: jboss/wildfly:10.0.0.Final
+    build:
+      context: ./.docker
+      dockerfile: Dockerfile-wildfly10
+    networks:
+      - default
+    ports:
+      - 127.0.0.1:8080:8080
+      - 127.0.0.1:9990:9990
+    command: []
+    volumes:
+      - ./.docker/deployments/:/opt/jboss/wildfly/standalone/deployments/ #copy files here to deploy
+      #- ./.docker/logs:/opt/jboss/wildfly/standalone/logs/ #surface logs if you want


### PR DESCRIPTION
Allows quicker testing in clean environments and have access to docker. aka current day cicd pipelines or on a mac, etc.