### PR TITLE
owasp for rest of modules and checkstyle inclusion

### DIFF
--- a/build-tools/src/main/resources/qa/owasp-dependency-checker-suppressions.xml
+++ b/build-tools/src/main/resources/qa/owasp-dependency-checker-suppressions.xml
@@ -2,17 +2,17 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 <!--
 2019 Oct 23
-[ERROR] infinispan-core-8.2.4.Final.jar: CVE-2017-2638, CVE-2017-15089, CVE-2016-0750
-[ERROR] jgroups-3.6.7.Final.jar: CWE-300: Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-[ERROR] hibernate-validator-5.2.5.Final.jar: CVE-2017-7536
-[ERROR] dom4j-1.6.1-brew.jar: CVE-2018-1000632
-[ERROR] drools-core-5.3.3.Final.jar: CVE-2014-8125
-[ERROR] knowledge-api-5.3.3.Final.jar: CVE-2014-8125
-[ERROR] bsh-2.0b4.jar: CVE-2016-2510
-[ERROR] oak-jackrabbit-api-1.16.0.jar: CVE-2015-1833
-[ERROR] httpclient-4.0.jar: CVE-2014-3577, CVE-2015-5262, CVE-2011-1498
-[ERROR] xercesImpl-2.8.1.jar: CVE-2012-0881
-[ERROR] testng-6.9.10.jar: jquery-1.7.1.min.js: CVE-2015-9251, CVE-2012-6708, CVE-2019-11358
+infinispan-core-8.2.4.Final.jar: CVE-2017-2638, CVE-2017-15089, CVE-2016-0750
+jgroups-3.6.7.Final.jar: CWE-300: Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
+hibernate-validator-5.2.5.Final.jar: CVE-2017-7536
+dom4j-1.6.1-brew.jar: CVE-2018-1000632
+drools-core-5.3.3.Final.jar: CVE-2014-8125
+knowledge-api-5.3.3.Final.jar: CVE-2014-8125
+bsh-2.0b4.jar: CVE-2016-2510
+oak-jackrabbit-api-1.16.0.jar: CVE-2015-1833
+httpclient-4.0.jar: CVE-2014-3577, CVE-2015-5262, CVE-2011-1498
+xercesImpl-2.8.1.jar: CVE-2012-0881
+testng-6.9.10.jar: jquery-1.7.1.min.js: CVE-2015-9251, CVE-2012-6708, CVE-2019-11358
 
  -->
     <suppress>
@@ -106,4 +106,152 @@
         <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
         <cve>CVE-2019-11358</cve>
     </suppress>
+<!-- on project jboss-seam-ui: annotations-4.5.0.Final.jar: CVE-2015-0279, CVE-2013-2165-->
+    <suppress>
+        <packageUrl regex="true">^pkg:maven/org\.richfaces\.cdk/annotations@.*$</packageUrl>
+        <cve>CVE-2013-2165</cve>
+    </suppress>
+    <suppress>
+        <packageUrl regex="true">^pkg:maven/org\.richfaces\.cdk/annotations@.*$</packageUrl>
+        <cve>CVE-2015-0279</cve>
+    </suppress>
+<!-- on project jboss-seam-gen: guava-19.0.jar: CVE-2018-10237 , primefaces-7.0.jar: CVE-2019-11358 -->
+    <suppress>
+        <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
+        <cve>CVE-2018-10237</cve>
+    </suppress>
+    <suppress>
+        <packageUrl regex="true">^pkg:maven/org\.primefaces/primefaces@.*$</packageUrl>
+        <vulnerabilityName>CVE-2019-11358</vulnerabilityName>
+    </suppress>
+<!-- on project jboss-seam-flex:  blazeds-core-3.2.0.3978.jar: CVE-2011-2093, CVE-2011-2092 blazeds-proxy-3.2.0.3978.jar: CVE-2011-2093, CVE-2011-2092 -->
+    <suppress>
+        <cve>CVE-2011-2092</cve>
+    </suppress>
+    <suppress>
+        <cve>CVE-2011-2093</cve>
+    </suppress>
+<!-- on project jboss-seam-remoting: gwt-servlet-1.5.2.jar: CVE-2007-2378, CVE-2013-4204 gwt-user-1.5.2.jar: CVE-2013-4204 -->
+    <suppress>
+        <cve>CVE-2007-2378</cve>
+    </suppress>
+    <suppress>
+        <cve>CVE-2013-4204</cve>
+    </suppress>
+    <suppress>
+        <cve>CVE-2013-4204</cve>
+    </suppress>
+<!-- on project jboss-seam-resteasy: resteasy-jaxrs-3.0.19.Final.jar: CVE-2016-9606 -->
+    <suppress>
+        <cve>CVE-2016-9606</cve>
+    </suppress>
+<!-- on project jboss-seam-wicket: 
+wicket-1.4.14.jar: CVE-2012-5636, CVE-2016-6793, CVE-2015-7520, CVE-2014-3526, CVE-2014-7808, CVE-2012-3373, CVE-2015-5347, CVE-2011-2712, CVE-2012-0047, CVE-2012-1089, CVE-2013-2055
+wicket-ioc-1.4.14.jar: CVE-2012-5636, CVE-2014-3526, CVE-2014-7808, CVE-2012-3373, CVE-2011-2712, CVE-2012-0047, CVE-2012-1089, CVE-2013-2055
+wicket-datetime-1.4.14.jar: calendar-min.js: CVE-2010-4208, CVE-2010-4207, CVE-2010-4710, CVE-2012-5881, CVE-2012-5882
+wicket-datetime-1.4.14.jar: calendar.js: CVE-2010-4208, CVE-2010-4207, CVE-2010-4710, CVE-2012-5881, CVE-2012-5882
+wicket-datetime-1.4.14.jar: yuiloader-min.js: CVE-2010-4208, CVE-2010-4207, CVE-2010-4710, CVE-2012-5881, CVE-2012-5882
+wicket-datetime-1.4.14.jar: dom-min.js: CVE-2010-4208, CVE-2010-4207, CVE-2010-4710, CVE-2012-5881, CVE-2012-5882
+wicket-datetime-1.4.14.jar: dom.js: CVE-2010-4208, CVE-2010-4207, CVE-2010-4710, CVE-2012-5881, CVE-2012-5882
+wicket-datetime-1.4.14.jar: yahoo-dom-event.js: CVE-2010-4208, CVE-2010-4207, CVE-2010-4710, CVE-2012-5881, CVE-2012-5882
+wicket-datetime-1.4.14.jar: yuiloader.js: CVE-2010-4208, CVE-2010-4207, CVE-2010-4710, CVE-2012-5881, CVE-2012-5882
+wicket-datetime-1.4.14.jar: event.js: CVE-2010-4208, CVE-2010-4207, CVE-2010-4710, CVE-2012-5881, CVE-2012-5882
+wicket-datetime-1.4.14.jar: event-min.js: CVE-2010-4208, CVE-2010-4207, CVE-2010-4710, CVE-2012-5881, CVE-2012-5882
+wicket-datetime-1.4.14.jar: yahoo.js: CVE-2010-4208, CVE-2010-4207, CVE-2010-4710, CVE-2012-5881, CVE-2012-5882
+wicket-datetime-1.4.14.jar: yahoo-min.js: CVE-2010-4208, CVE-2010-4207, CVE-2010-4710, CVE-2012-5881, CVE-2012-5882
+
+Cross-site scripting (XSS) vulnerability in Apache Wicket 1.4.x before 1.4.18, when setAutomaticMultiWindowSupport is enabled, allows remote attackers to inject arbitrary web script or HTML via unspecified parameters.
+Cross-site scripting (XSS) vulnerability in the addItem method in the Menu widget in YUI(inside wicket-datetime-1.4.14.jar) before 2.9.0 allows remote attackers to inject arbitrary web script or HTML
+-->
+    <suppress>
+        <vulnerabilityName>CVE-2012-5636</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <vulnerabilityName>CVE-2016-6793</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <vulnerabilityName>CVE-2015-7520</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <vulnerabilityName>CVE-2014-3526</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <vulnerabilityName>CVE-2014-7808</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <vulnerabilityName>CVE-2012-3373</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <vulnerabilityName>CVE-2015-5347</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <vulnerabilityName>CVE-2011-2712</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <vulnerabilityName>CVE-2012-0047</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <vulnerabilityName>CVE-2012-1089</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <vulnerabilityName>CVE-2013-2055</vulnerabilityName>
+    </suppress>
+
+    <suppress>
+        <vulnerabilityName>CVE-2010-4208</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <vulnerabilityName>CVE-2010-4207</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <vulnerabilityName>CVE-2010-4710</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <vulnerabilityName>CVE-2012-5881</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <vulnerabilityName>CVE-2012-5882</vulnerabilityName>
+    </suppress>
+<!-- on project jboss-seam-ioc: 
+spring-core-3.1.4.RELEASE.jar: CVE-2013-4152, CVE-2014-1904, CVE-2014-0054, CVE-2013-6429, CVE-2014-3578, CVE-2014-0225, CVE-2014-3625, CVE-2018-1272, CVE-2013-7315, CVE-2016-9878, CVE-2018-1271, CVE-2018-1270
+spring-tx-3.1.4.RELEASE.jar: CVE-2013-4152, CVE-2014-1904, CVE-2014-0054, CVE-2013-6429, CVE-2018-1272, CVE-2013-7315, CVE-2016-9878, CVE-2018-1271, CVE-2018-1270
+spring-web-3.1.4.RELEASE.jar: CVE-2013-4152, CVE-2014-1904, CVE-2014-0054, CVE-2013-6429, CVE-2014-0225, CVE-2018-1272, CVE-2013-7315, CVE-2016-9878, CVE-2018-1271, CVE-2018-1270
+-->
+    <suppress>
+        <cve>CVE-2013-4152</cve>
+    </suppress>
+    <suppress>
+        <cve>CVE-2014-1904</cve>
+    </suppress>
+    <suppress>
+        <cve>CVE-2014-0054</cve>
+    </suppress>
+    <suppress>
+        <cve>CVE-2013-6429</cve>
+    </suppress>
+    <suppress>
+        <cve>CVE-2014-3578</cve>
+    </suppress>
+    <suppress>
+        <cve>CVE-2014-0225</cve>
+    </suppress>
+    <suppress>
+        <cve>CVE-2014-3625</cve>
+    </suppress>
+    <suppress>
+        <cve>CVE-2018-1272</cve>
+    </suppress>
+    <suppress>
+        <cve>CVE-2013-7315</cve>
+    </suppress>
+    <suppress>
+        <cve>CVE-2016-9878</cve>
+    </suppress>
+    <suppress>
+        <cve>CVE-2018-1271</cve>
+    </suppress>
+    <suppress>
+        <cve>CVE-2018-1270</cve>
+    </suppress>
+
 </suppressions>

--- a/jboss-seam-debug/pom.xml
+++ b/jboss-seam-debug/pom.xml
@@ -30,31 +30,33 @@
     </dependencies>
     <build>
     	<plugins>
-    		<plugin>
-			    <groupId>com.github.spotbugs</groupId>
-			    <artifactId>spotbugs-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>spotbugs-check</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>check</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-pmd-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>check</goal>
-							<goal>cpd-check</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <dotGitDirectory>${project.basedir}/../.git</dotGitDirectory>
+                    <!-- this is false by default, forces the plugin to generate the git.properties file -->
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <!-- The path for the properties file to be generated. See Super Pom for default variable reference https://maven.apache.org/guides/introduction/introduction-to-the-pom.html -->
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+            </plugin>
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>

--- a/jboss-seam-debug/pom.xml
+++ b/jboss-seam-debug/pom.xml
@@ -55,6 +55,10 @@
 					</execution>
 				</executions>
 			</plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+            </plugin>
     	</plugins>
     </build>
 

--- a/jboss-seam-excel/pom.xml
+++ b/jboss-seam-excel/pom.xml
@@ -69,6 +69,22 @@
 
     <build>
     	<plugins>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <dotGitDirectory>${project.basedir}/../.git</dotGitDirectory>
+                    <!-- this is false by default, forces the plugin to generate the git.properties file -->
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <!-- The path for the properties file to be generated. See Super Pom for default variable reference https://maven.apache.org/guides/introduction/introduction-to-the-pom.html -->
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
     		<plugin>
 			    <groupId>com.github.spotbugs</groupId>
 			    <artifactId>spotbugs-maven-plugin</artifactId>
@@ -94,32 +110,13 @@
 					</execution>
 				</executions>
 			</plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+            </plugin>
     	</plugins>
     </build>
     <profiles>
-        <profile>
-            <id>code-coverage</id>
-            <build>
-                <plugins>
-                    <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-            </plugin>
-                    <plugin>
-                      <groupId>org.apache.maven.plugins</groupId>
-                      <artifactId>maven-antrun-plugin</artifactId>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.sonatype.maven.plugin</groupId>
-                        <artifactId>emma4it-maven-plugin</artifactId>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
          <profile>
             <id>distribution</id>
             <build>

--- a/jboss-seam-excel/pom.xml
+++ b/jboss-seam-excel/pom.xml
@@ -85,30 +85,16 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
     		<plugin>
 			    <groupId>com.github.spotbugs</groupId>
 			    <artifactId>spotbugs-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>spotbugs-check</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>check</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>check</goal>
-							<goal>cpd-check</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
             <plugin>
                 <groupId>org.owasp</groupId>

--- a/jboss-seam-flex/pom.xml
+++ b/jboss-seam-flex/pom.xml
@@ -66,30 +66,16 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
     		<plugin>
 			    <groupId>com.github.spotbugs</groupId>
 			    <artifactId>spotbugs-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>spotbugs-check</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>check</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>check</goal>
-							<goal>cpd-check</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
             <plugin>
                 <groupId>org.owasp</groupId>

--- a/jboss-seam-flex/pom.xml
+++ b/jboss-seam-flex/pom.xml
@@ -50,6 +50,22 @@
 
 <build>
     	<plugins>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <dotGitDirectory>${project.basedir}/../.git</dotGitDirectory>
+                    <!-- this is false by default, forces the plugin to generate the git.properties file -->
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <!-- The path for the properties file to be generated. See Super Pom for default variable reference https://maven.apache.org/guides/introduction/introduction-to-the-pom.html -->
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
     		<plugin>
 			    <groupId>com.github.spotbugs</groupId>
 			    <artifactId>spotbugs-maven-plugin</artifactId>
@@ -75,6 +91,10 @@
 					</execution>
 				</executions>
 			</plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+            </plugin>
     	</plugins>
     </build>
     <profiles>

--- a/jboss-seam-gen/pom.xml
+++ b/jboss-seam-gen/pom.xml
@@ -47,7 +47,7 @@
    				</execution>
    			</executions>
    		</plugin>
-   		<plugin>
+        <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
             <executions>
@@ -78,19 +78,22 @@
                 </goals>
               </execution>
             </executions>
-          </plugin>
-    		<plugin>
-			    <groupId>com.github.spotbugs</groupId>
-			    <artifactId>spotbugs-maven-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-pmd-plugin</artifactId>
-			</plugin>
-            <plugin>
-                <groupId>org.owasp</groupId>
-                <artifactId>dependency-check-maven</artifactId>
-            </plugin>
+        </plugin>
+        <plugin>
+            <artifactId>maven-checkstyle-plugin</artifactId>
+        </plugin>
+        <plugin>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-maven-plugin</artifactId>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-pmd-plugin</artifactId>
+        </plugin>
+        <plugin>
+            <groupId>org.owasp</groupId>
+            <artifactId>dependency-check-maven</artifactId>
+        </plugin>
    	</plugins>
    </build>
    

--- a/jboss-seam-gen/pom.xml
+++ b/jboss-seam-gen/pom.xml
@@ -48,37 +48,37 @@
    			</executions>
    		</plugin>
    		<plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>generate build.properties</id>
-            <phase>generate-sources</phase>
-            <configuration>
-              <target>
-                <echo file="${project.basedir}/../build/build.properties">
-                  complete.version=${project.version}${line.separator}version=${project.short.version}
-                </echo>
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>clean build.properties</id>
-            <phase>clean</phase>
-            <configuration>
-              <target>
-                <delete file="${project.basedir}/../build/build.properties" />
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>generate build.properties</id>
+                <phase>generate-sources</phase>
+                <configuration>
+                  <target>
+                    <echo file="${project.basedir}/../build/build.properties">
+                      complete.version=${project.version}${line.separator}version=${project.short.version}
+                    </echo>
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>clean build.properties</id>
+                <phase>clean</phase>
+                <configuration>
+                  <target>
+                    <delete file="${project.basedir}/../build/build.properties" />
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
     		<plugin>
 			    <groupId>com.github.spotbugs</groupId>
 			    <artifactId>spotbugs-maven-plugin</artifactId>
@@ -87,6 +87,10 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
 			</plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+            </plugin>
    	</plugins>
    </build>
    

--- a/jboss-seam-ioc/pom.xml
+++ b/jboss-seam-ioc/pom.xml
@@ -112,6 +112,10 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
 			</plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+            </plugin>
     	</plugins>
     </build>
     <profiles>

--- a/jboss-seam-ioc/pom.xml
+++ b/jboss-seam-ioc/pom.xml
@@ -104,7 +104,10 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
-    		<plugin>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
 			    <groupId>com.github.spotbugs</groupId>
 			    <artifactId>spotbugs-maven-plugin</artifactId>
 			</plugin>

--- a/jboss-seam-mail/pom.xml
+++ b/jboss-seam-mail/pom.xml
@@ -60,7 +60,10 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
-    		<plugin>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
 			    <groupId>com.github.spotbugs</groupId>
 			    <artifactId>spotbugs-maven-plugin</artifactId>
 			</plugin>

--- a/jboss-seam-mail/pom.xml
+++ b/jboss-seam-mail/pom.xml
@@ -68,6 +68,10 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
 			</plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+            </plugin>
     	</plugins>
     </build>
     <profiles>

--- a/jboss-seam-pdf/pom.xml
+++ b/jboss-seam-pdf/pom.xml
@@ -76,6 +76,10 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
 			</plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+            </plugin>
     	</plugins>
     </build>
     <profiles>

--- a/jboss-seam-pdf/pom.xml
+++ b/jboss-seam-pdf/pom.xml
@@ -50,7 +50,7 @@
             <artifactId>jboss-jsf-api_2.2_spec</artifactId>
         </dependency>
     </dependencies>
-<build>
+    <build>
     	<plugins>
             <plugin>
                 <groupId>pl.project13.maven</groupId>
@@ -68,7 +68,10 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
-    		<plugin>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
 			    <groupId>com.github.spotbugs</groupId>
 			    <artifactId>spotbugs-maven-plugin</artifactId>
 			</plugin>

--- a/jboss-seam-remoting/pom.xml
+++ b/jboss-seam-remoting/pom.xml
@@ -47,7 +47,10 @@
 					<jsSrcDir>src/main/resources/org/jboss/seam/remoting/</jsSrcDir>
 				</configuration>
 			</plugin>
-    		<plugin>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
 			    <groupId>com.github.spotbugs</groupId>
 			    <artifactId>spotbugs-maven-plugin</artifactId>
 			</plugin>

--- a/jboss-seam-remoting/pom.xml
+++ b/jboss-seam-remoting/pom.xml
@@ -55,6 +55,10 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
 			</plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+            </plugin>
 		</plugins>
 	</build>
 
@@ -106,29 +110,6 @@
     </dependencies>
 
     <profiles>
-        <profile>
-            <id>code-coverage</id>
-            <build>
-                <plugins>
-                    <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-            </plugin>
-                    <plugin>
-                      <groupId>org.apache.maven.plugins</groupId>
-                      <artifactId>maven-antrun-plugin</artifactId>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.sonatype.maven.plugin</groupId>
-                        <artifactId>emma4it-maven-plugin</artifactId>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
          <profile>
             <id>distribution</id>
             <build>

--- a/jboss-seam-resteasy/pom.xml
+++ b/jboss-seam-resteasy/pom.xml
@@ -99,6 +99,10 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
 			</plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+            </plugin>
     	</plugins>
     </build>
     <profiles>

--- a/jboss-seam-resteasy/pom.xml
+++ b/jboss-seam-resteasy/pom.xml
@@ -91,7 +91,10 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
-    		<plugin>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
 			    <groupId>com.github.spotbugs</groupId>
 			    <artifactId>spotbugs-maven-plugin</artifactId>
 			</plugin>

--- a/jboss-seam-rss/pom.xml
+++ b/jboss-seam-rss/pom.xml
@@ -59,7 +59,10 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
-    		<plugin>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
 			    <groupId>com.github.spotbugs</groupId>
 			    <artifactId>spotbugs-maven-plugin</artifactId>
 			</plugin>

--- a/jboss-seam-rss/pom.xml
+++ b/jboss-seam-rss/pom.xml
@@ -67,6 +67,10 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
 			</plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+            </plugin>
     	</plugins>
     </build>
     <profiles>

--- a/jboss-seam-ui/pom.xml
+++ b/jboss-seam-ui/pom.xml
@@ -101,6 +101,10 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
 			</plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+            </plugin>
         </plugins>
         <pluginManagement>
            <plugins>

--- a/jboss-seam-ui/pom.xml
+++ b/jboss-seam-ui/pom.xml
@@ -93,7 +93,10 @@
                     </execution>
                 </executions>
             </plugin>
-    		<plugin>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
 			    <groupId>com.github.spotbugs</groupId>
 			    <artifactId>spotbugs-maven-plugin</artifactId>
 			</plugin>

--- a/jboss-seam-wicket/pom.xml
+++ b/jboss-seam-wicket/pom.xml
@@ -108,6 +108,10 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
 			</plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+            </plugin>
     	</plugins>
     </build>
     <profiles>

--- a/jboss-seam-wicket/pom.xml
+++ b/jboss-seam-wicket/pom.xml
@@ -100,7 +100,10 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
-    		<plugin>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
 			    <groupId>com.github.spotbugs</groupId>
 			    <artifactId>spotbugs-maven-plugin</artifactId>
 			</plugin>

--- a/jboss-seam/pom.xml
+++ b/jboss-seam/pom.xml
@@ -133,33 +133,15 @@
                 </executions>
             </plugin>
             <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
 			    <groupId>com.github.spotbugs</groupId>
 			    <artifactId>spotbugs-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>spotbugs-check</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>check</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
-				<configuration>
-					<verbose>true</verbose>
-					<failOnViolation>false</failOnViolation>
-				</configuration>
-				<executions>
-					<execution>
-						<goals>
-							<goal>check</goal>
-							<goal>cpd-check</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,8 +80,11 @@
 		<maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
         <maven.compiler.target>1.7</maven.compiler.target>
         <maven.compiler.source>1.7</maven.compiler.source>
-        
+
         <jacoco.skip>false</jacoco.skip>
+        <dependency.skip>false</dependency.skip>
+        <spotbugs.skip>false</spotbugs.skip>
+        <pmd.skip>false</pmd.skip>
 	</properties>
 
 	<dependencyManagement>
@@ -630,6 +633,17 @@
    </modules>
 
     <profiles>
+        <profile>
+            <id>quickrun</id> <!-- to disable pmd/spotbugs/owasp check for quick runs mvn ${command} -Pquickrun -->
+            <properties>
+                <jacoco.skip>true</jacoco.skip>
+                <dependency.skip>true</dependency.skip>
+                <pmd.skip>true</pmd.skip>
+                <findbugs.skip>true</findbugs.skip>
+                <spotbugs.skip>true</spotbugs.skip>
+                <skip.clear.db>true</skip.clear.db>
+            </properties>
+        </profile>
        <!-- Profile for generating Seam reference documentation  -->
        <profile>
            <id>doc</id>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,9 @@
         <dependency.skip>false</dependency.skip>
         <spotbugs.skip>false</spotbugs.skip>
         <pmd.skip>false</pmd.skip>
+        <checkstyle.skip>true</checkstyle.skip><!-- turn on once we have a checkstyle file we want to meet -->
+        <checkstyle.failsOnErrors>false</checkstyle.failsOnErrors><!-- turn on once we have a checkstyle happy -->
+        <checkstyle.failOnViolation>false</checkstyle.failOnViolation><!-- turn on once we have a checkstyle happy -->
 	</properties>
 
 	<dependencyManagement>
@@ -444,17 +447,6 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-checkstyle-plugin</artifactId><version>${version.maven-checkstyle-plugin}</version>
-                    <configuration>
-                        <includeTestSourceDirectory>true</includeTestSourceDirectory>
-                        <configLocation>qa/checkstyle_rules.xml</configLocation>
-                        <logViolationsToConsole>true</logViolationsToConsole>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <phase>prepare-package</phase>
-                            <goals><goal>check</goal></goals>
-                        </execution>
-                    </executions>
                     <dependencies>
                         <dependency>
                             <groupId>org.jboss.seam</groupId>
@@ -462,11 +454,29 @@
                             <version>1.0-SNAPSHOT</version>
                         </dependency>
                     </dependencies>
+                    <configuration>
+                        <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                        <configLocation>qa/checkstyle_rules.xml</configLocation>
+                        <logViolationsToConsole>true</logViolationsToConsole>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <phase>validate</phase>
+                            <goals><goal>check</goal></goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
                     <version>${version.spotbugs-maven-plugin}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.jboss.seam</groupId>
+                            <artifactId>build-tools</artifactId>
+                            <version>1.0-SNAPSHOT</version>
+                        </dependency>
+                    </dependencies>
                     <configuration>
                         <excludeFilterFile>qa/findbugs-exclude.xml</excludeFilterFile>
                         <effort>Max</effort>
@@ -479,13 +489,15 @@
 <!--                            <plugin><groupId>com.mebigfatguy.sb-contrib</groupId><artifactId>sb-contrib</artifactId><version>${version.sb-contrib}</version></plugin>-->
 <!--                        </plugins>-->
                     </configuration>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.jboss.seam</groupId>
-                            <artifactId>build-tools</artifactId>
-                            <version>1.0-SNAPSHOT</version>
-                        </dependency>
-                    </dependencies>
+                    <executions>
+                        <execution>
+                            <id>spotbugs-check</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -534,6 +546,13 @@
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
                     <version>${version.org.owasp.dependency-check-maven}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.jboss.seam</groupId>
+                            <artifactId>build-tools</artifactId>
+                            <version>1.0-SNAPSHOT</version>
+                        </dependency>
+                    </dependencies>
                     <configuration>
                         <suppressionFile>qa/owasp-dependency-checker-suppressions.xml</suppressionFile>
                         <failBuildOnCVSS>1</failBuildOnCVSS>
@@ -545,13 +564,6 @@
                             <goals><goal>check</goal></goals>
                         </execution>
                     </executions>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.jboss.seam</groupId>
-                            <artifactId>build-tools</artifactId>
-                            <version>1.0-SNAPSHOT</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
 			</plugins>
 		</pluginManagement>
@@ -636,12 +648,9 @@
         <profile>
             <id>quickrun</id> <!-- to disable pmd/spotbugs/owasp check for quick runs mvn ${command} -Pquickrun -->
             <properties>
-                <jacoco.skip>true</jacoco.skip>
                 <dependency.skip>true</dependency.skip>
                 <pmd.skip>true</pmd.skip>
-                <findbugs.skip>true</findbugs.skip>
                 <spotbugs.skip>true</spotbugs.skip>
-                <skip.clear.db>true</skip.clear.db>
             </properties>
         </profile>
        <!-- Profile for generating Seam reference documentation  -->


### PR DESCRIPTION
added owasp and ignored the current issues it found. -_-

plugged in checkstyle into all main modules and then disabled it (for now) as it generates 3k on just the seam core etc.

Do you like the linting rules in the checkstyle file 
https://github.com/albfernandez/jboss-seam/blob/Seam_2_3_jee7/build-tools/src/main/resources/qa/checkstyle_rules.xml

or do you have your own that you want to use? 

One your happy, I'll do another code reformat (via ide post loading checkstyle config) to align it and then enable the error on violation from then on.