### PR TITLE
Travis fast finish with examples trying to be compiled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,53 @@
+# Java Maven CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-java/ for more details
+#
+version: 2
+
+shared: &shared
+  working_directory: ~/repo
+
+  environment:
+    # Customize the JVM maximum heap limit
+    MAVEN_OPTS: -Xmx3200m
+
+  steps:
+    - checkout
+
+    # Download and cache dependencies
+    - restore_cache:
+        keys:
+          - jboss-seam-{{ checksum "pom.xml" }}
+          # fallback to using the latest cache if no exact match is found
+          - jboss-seam-
+
+    # run tests!
+    - run: mvn test-compile
+    # run tests!
+    - run: mvn verify
+
+    - save_cache:
+        paths:
+          - ~/.m2
+        key: jboss-seam-{{ checksum "pom.xml" }}
+
+# Specify service dependencies here if necessary
+# CircleCI maintains a library of pre-built images
+# documented at https://circleci.com/docs/2.0/circleci-images/
+
+jobs:
+  jdk8:
+    <<: *shared
+    docker:
+      - image: circleci/openjdk:8-jdk
+#  jdk11:
+#    <<: *shared
+#    docker:
+#      - image: circleci/openjdk:11-jdk
+
+workflows:
+  version: 2
+  work:
+    jobs:
+      - jdk8
+#      - jdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,46 @@ cache:
 
 jdk:
   - openjdk8
-#  - openjdk10
-#  - openjdk11
+  - openjdk11
+
+before_script:
+  - echo $HOME
+  - echo $JAVA_OPTS
+  - echo $MAVEN_OPTS
+
+install: true
 
 jobs:
+  fast_finish: true
   include:
-    # compile check is fast
-    - stage: install
-      script: mvn test-compile -DskipTests=true -Dgpg.skip=true -B -q
-    # verify
-    - stage: test
-      script: mvn verify -B
+    - stage: quick
+      script:  "mvn clean test-compile -Dcheckstyle.skip=true -Dgpg.skip=true -B -V -Pquickrun"
+      name: "Jboss Core: test-compile"
+    - script: "mvn test-compile -Dcheckstyle.skip=true -Dgpg.skip=true -B -V -Pquickrun,all"
+      name: "Jboss Core + examples: test-compile"
+      env: CANFAIL=true
+    - stage: long
+      script: "mvn verify -Dcheckstyle.skip=true -Dgpg.skip=true -B -V -Pquickrun"
+      name: "Jboss Core: verify"
+    - script: "mvn package -Dcheckstyle.skip=true -Dgpg.skip=true -B -V -Pquickrun,all"
+      name: "Jboss Core + examples: verify"
+      env: CANFAIL=true
+  allow_failures:
+    - jdk: openjdk8
+      env: CANFAIL=true
+    - jdk: openjdk11
+    - jdk: openjdk11
+      env: CANFAIL=true
+#    - stage: integration
+#      script: "mvn test-compile -Dcheckstyle.skip=true -Dgpg.skip=true -B -V -Pquickrun,all"
+#      name: "Integration Wildfly 10"
+#    - script:
+#        - "docker-compose up as7"
+#        - "mvn package -Dcheckstyle.skip=true -Dgpg.skip=true -B -V -Pquickrun,all"
+#      name: "Integration JBoss AS 7"
 
+#    - stage: integration
 
+stages:
+  - quick
+  - long

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ cache:
 
 jdk:
   - openjdk8
-  - openjdk11
 
 before_script:
   - echo $HOME
@@ -24,19 +23,39 @@ jobs:
     - stage: quick
       script:  "mvn clean test-compile -Dcheckstyle.skip=true -Dgpg.skip=true -B -V -Pquickrun"
       name: "Jboss Core: test-compile"
+      jdk: openjdk8
+    - script:  "mvn clean test-compile -Dcheckstyle.skip=true -Dgpg.skip=true -B -V -Pquickrun"
+      name: "Jboss Core: test-compile - jdk11"
+      env: CANFAIL=true
+      jdk: openjdk11
     - script: "mvn test-compile -Dcheckstyle.skip=true -Dgpg.skip=true -B -V -Pquickrun,all"
       name: "Jboss Core + examples: test-compile"
       env: CANFAIL=true
+      jdk: openjdk8
+    - script: "mvn test-compile -Dcheckstyle.skip=true -Dgpg.skip=true -B -V -Pquickrun,all"
+      name: "Jboss Core + examples: test-compile -jdk11"
+      env: CANFAIL=true
+      jdk: openjdk11
+
     - stage: long
       script: "mvn verify -Dcheckstyle.skip=true -Dgpg.skip=true -B -V -Pquickrun"
       name: "Jboss Core: verify"
+      jdk: openjdk8
+    - script: "mvn verify -Dcheckstyle.skip=true -Dgpg.skip=true -B -V -Pquickrun"
+      name: "Jboss Core: verify -jdk11"
+      env: CANFAIL=true
+      jdk: openjdk11
     - script: "mvn package -Dcheckstyle.skip=true -Dgpg.skip=true -B -V -Pquickrun,all"
       name: "Jboss Core + examples: verify"
       env: CANFAIL=true
+      jdk: openjdk8
+    - script: "mvn package -Dcheckstyle.skip=true -Dgpg.skip=true -B -V -Pquickrun,all"
+      name: "Jboss Core + examples: verify -jdk11"
+      env: CANFAIL=true
+      jdk: openjdk11
   allow_failures:
     - jdk: openjdk8
       env: CANFAIL=true
-    - jdk: openjdk11
     - jdk: openjdk11
       env: CANFAIL=true
 #    - stage: integration


### PR DESCRIPTION
Better travis builds where examples are tried to be built after the core modules pass. 

I've including quickrun profile to skip most of the spotbugs/owasp/checkstyle etc so that we get faster turn around times. These can be turned on once we want it to enforce those checks instead of just giving us console logs. We still get jacoco code coverage and tests run which is good.

I've also including a token circleci config as an alternative to travis-ci. It is also free.

Next step I want to add is integration tests with a stock Application Server.

Which server's would you like tested against? I'm going to go with Wildfly 10 and which one is the min we should try against?