### PR TITLE
Use finelExpirationDate, no expirationDate

### DIFF
--- a/jboss-seam/src/main/java/org/jboss/seam/async/QuartzDispatcher.java
+++ b/jboss-seam/src/main/java/org/jboss/seam/async/QuartzDispatcher.java
@@ -144,7 +144,7 @@ public class QuartzDispatcher extends AbstractDispatcher<QuartzTriggerHandle, Sc
 			
 			Trigger trigger = TriggerBuilder.newTrigger().withIdentity(triggerName)
 					.withSchedule(CronScheduleBuilder.cronSchedule(cronSchedule.getCron()))
-					.endAt(cronSchedule.getExpiration())
+					.endAt(cronSchedule.getFinalExpiration())
 					.startAt(startTime)
 					.build();
 			


### PR DESCRIPTION
The wrong date is used as end date for the trigger. This leads to an exception, because the trigger will never be fired.